### PR TITLE
Add AGENTS.md with cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository contains two independent products:
+
+1. **Python library (`app/tilearn`)** — a scheduling/time-management optimization package (Python ≥ 3.10).
+2. **Documentation site (`docs/`)** — a Docusaurus 3.x static site (Node ≥ 20).
+
+### Running the Python library
+
+```bash
+pip install -e .                # editable install from repo root
+python -c "import tilearn as tl; print(tl.wspt([['J1',2,0,8,4]]))"
+```
+
+No external services (databases, Docker, etc.) are required. The library is file-system-based (CSV I/O).
+
+### Running the docs site (dev mode)
+
+```bash
+cd docs
+npm ci
+npm start          # serves at http://localhost:3000/TiLearn/
+```
+
+The `baseUrl` is `/TiLearn/`, so the root page is at `http://localhost:3000/TiLearn/`.
+
+### Lint / Typecheck
+
+- **Docs TypeScript check**: `cd docs && npx tsc --noEmit`
+- **Docs build** (also serves as a lint-like check for broken links): `cd docs && npm run build`
+- There is no Python linter or test runner configured in the repo currently.
+
+### Notes
+
+- `mkdocs.yml` at the repo root is legacy/unused — the active docs system is Docusaurus in `docs/`.
+- The `run.py` at the repo root imports from `tilearn` and exercises all the module's public APIs. It is not a runnable script on its own (it only defines imports).
+- Docusaurus build produces warnings about broken anchors in API reference pages — these are pre-existing and unrelated to env setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future agents working in this repository.

## What's included

- Description of the two products (Python library + Docusaurus docs site)
- Commands for running/testing each product
- Lint/typecheck commands
- Notes about legacy config files and known build warnings

## Verified

- Python library installs and runs scheduling algorithms (WSPT, EDD) correctly
- Docs site builds without errors and runs in dev mode at `http://localhost:3000/TiLearn/`
- TypeScript typecheck passes cleanly

[TiLearn docs homepage running in dev mode](https://cursor.com/agents/bc-4999893a-5114-485c-baa8-cdf4da8a558f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_homepage.webp)
[Getting started documentation page](https://cursor.com/agents/bc-4999893a-5114-485c-baa8-cdf4da8a558f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgetting_started_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4999893a-5114-485c-baa8-cdf4da8a558f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4999893a-5114-485c-baa8-cdf4da8a558f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

